### PR TITLE
update code to include rpc handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 MAINNET_SOL_PRIVATE_KEY=your_solana_private_key_here
 MAINNET_ETH_PRIVATE_KEY=your_ethereum_private_key_here 
+ETHEREUM_MAINNET_RPC=https://eth-mainnet.public.blastapi.io

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,6 +8,8 @@ import {
   } from "@wormhole-foundation/sdk-connect";
   import { getEvmSignerForKey } from "@wormhole-foundation/sdk-evm";
   import { getSolanaSigner } from "@wormhole-foundation/sdk-solana";
+  import { JsonRpcProvider } from "ethers";
+  import { config as dotenv } from "dotenv"; dotenv(); 
 
 // Helper function to get environment variables
 function getEnv(key: string): string {
@@ -43,8 +45,10 @@ export async function getSigner<N extends Network, C extends Chain>(
       );
       break;
     case "Evm":
+      const rpcUrl = process.env.ETHEREUM_MAINNET_RPC;
+      const rpc = new JsonRpcProvider(rpcUrl, { chainId: 1, name: "mainnet" });
       signer = await getEvmSignerForKey(
-        await chain.getRpc(),
+        rpc,
         getEnv("MAINNET_ETH_PRIVATE_KEY")
       );
       break;

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -15,7 +15,14 @@ dotenv.config();
 
 (async function () {
   // Setup
-  const wh = new Wormhole("Mainnet", [EvmPlatform, SolanaPlatform]);
+  const wh = new Wormhole("Mainnet", [EvmPlatform, SolanaPlatform], {
+    chains: {
+      Ethereum: { rpc: process.env.ETHEREUM_MAINNET_RPC! }, // e.g. https://ethereum-rpc.publicnode.com
+      Solana: {
+        rpc: process.env.SOLANA_MAINNET_RPC ?? "https://api.mainnet-beta.solana.com",
+      },
+    },
+  });
 
   const sendChain = wh.getChain("Base");
   const destChain = wh.getChain("Solana");


### PR DESCRIPTION
This pull request introduces support for specifying custom RPC URLs for Ethereum and Solana mainnets via environment variables, improving flexibility and configuration for mainnet connections. The changes ensure that the application consistently uses these environment variables when initializing providers and signers.

**Environment configuration improvements:**

* Added a new `ETHEREUM_MAINNET_RPC` variable to `.env.example` to allow specifying a custom Ethereum mainnet RPC endpoint.
* Updated `src/helpers.ts` to load environment variables using `dotenv` for easier configuration management.

**Ethereum RPC integration:**

* Modified the EVM signer logic in `src/helpers.ts` to use the `ETHEREUM_MAINNET_RPC` environment variable when creating a `JsonRpcProvider`, ensuring consistent use of the configured endpoint.

**Solana/Ethereum RPC usage in initialization:**

* Updated the Wormhole initialization in `src/swap.ts` to use the custom RPC URLs from environment variables for both Ethereum and Solana chains, with a fallback for Solana.